### PR TITLE
Add PHP Redis extension to all Docker images (apache, fpm, fpm-alpine)

### DIFF
--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -34,6 +34,7 @@ RUN set -ex; \
     # END: Install php-zmq
     \
     pecl install ev; \
+    pecl install redis; \
     \
     docker-php-ext-configure ldap \
         --with-libdir="lib/$(dpkg-architecture --query DEB_BUILD_MULTIARCH)" \
@@ -58,6 +59,7 @@ RUN set -ex; \
     docker-php-ext-enable \
         zmq \
         ev \
+        redis \
     ; \
     \
 # reset a list of apt-mark

--- a/fpm-alpine/Dockerfile
+++ b/fpm-alpine/Dockerfile
@@ -32,6 +32,7 @@ RUN set -ex; \
     # END: Install php-zmq
     \
     pecl install ev; \
+    pecl install redis; \
     \
     docker-php-ext-configure gd \
         --with-freetype \
@@ -52,7 +53,8 @@ RUN set -ex; \
     ; \
     docker-php-ext-enable \
         zmq \
-        ev
+        ev \
+        redis
 
 # php.ini
 RUN { \

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -34,6 +34,7 @@ RUN set -ex; \
     # END: Install php-zmq
     \
     pecl install ev; \
+    pecl install redis; \
     \
     docker-php-ext-configure ldap \
         --with-libdir="lib/$(dpkg-architecture --query DEB_BUILD_MULTIARCH)" \
@@ -58,6 +59,7 @@ RUN set -ex; \
     docker-php-ext-enable \
         zmq \
         ev \
+        redis \
     ; \
     \
 # reset a list of apt-mark


### PR DESCRIPTION

### What
This PR adds installation and runtime enablement of the PHP `redis` extension in all three Docker image variants in `espocrm-docker`:

- `espocrm-docker/apache/Dockerfile`
- `espocrm-docker/fpm/Dockerfile`
- `espocrm-docker/fpm-alpine/Dockerfile`

### Why
Redis is required to support shared PHP sessions via `session.save_handler=redis`.

This is important for High Availability (HA) deployments of EspoCRM, where multiple application instances run behind a load balancer and must share session state consistently.

### Changes
- Added `pecl install redis` during image build.
- Added `redis` to `docker-php-ext-enable` so the extension is loaded at runtime.

### Validation
- Docker image build was executed successfully for the updated variant.
- Runtime extension check can be done with:
  - `php -m | grep -i '^redis$'`

### Impact
- No application-level behavior change by default.
- Enables Redis-backed PHP session storage for HA/multi-node deployments.